### PR TITLE
Enable Chinese language preference in settings

### DIFF
--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -18,6 +18,85 @@ interface UserSettings {
   language: 'zh-CN' | 'en-US';
 }
 
+// Simple translation dictionary for English and Chinese
+const translations = {
+  'en-US': {
+    accountSettings: 'Account Settings',
+    backToUpload: '\u2190 Back to Upload',
+    logout: 'Logout',
+    apiConfiguration: '\ud83d\udd11 API Configuration',
+    apiDescription:
+      'Configure your own Doubao API key for homework analysis. Get your API key from',
+    apiConsole: 'Volcengine ARK Console',
+    apiKeyLabel: 'Doubao API Key',
+    test: 'Test',
+    helpText:
+      "Your API key is stored locally and never shared. Without a key, you'll use the demo mode.",
+    preferences: '\u2699\ufe0f Preferences',
+    language: 'Language',
+    optionChinese: '\u4e2d\u6587 (Chinese)',
+    optionEnglish: 'English',
+    enableNotifications: 'Enable notifications',
+    saveSettings: 'Save Settings',
+    saving: 'Saving...',
+    savedSuccess: 'Settings saved successfully!',
+    invalidApiKeyFormat: 'Invalid API key format. Please check your key.',
+    pleaseEnterApiKeyFirst: 'Please enter an API key first',
+    testingApiKey: 'Testing API key...',
+    invalidApiKey: '\u274c Invalid API key',
+    apiKeyQuotaExceeded: '\u26a0\ufe0f API key valid but quota exceeded',
+    apiKeyValid: '\u2705 API key is valid',
+    unexpectedResponse: '\u26a0\ufe0f Unexpected response:',
+    networkError: '\u274c Network error or invalid API key',
+    apiUsageInfo: '\ud83d\udccb API Usage Information',
+    model: 'Model:',
+    features: 'Features:',
+    featuresDesc: 'Chinese text recognition, error detection',
+    cost: 'Cost:',
+    costDesc: 'Pay-per-use based on your Volcengine plan',
+    security: 'Security:',
+    securityDesc: 'API key stored locally, not on our servers',
+  },
+  'zh-CN': {
+    accountSettings: '\u8d26\u6237\u8bbe\u7f6e',
+    backToUpload: '\u2190 \u8fd4\u56de\u4e0a\u4f20',
+    logout: '\u9000\u51fa\u767b\u5f55',
+    apiConfiguration: '\ud83d\udd11 API\u914d\u7f6e',
+    apiDescription: '\u914d\u7f6e\u60a8\u7684\u8c46\u5305API\u5bc6\u94a5\u7528\u4e8e\u4f5c\u4e1a\u5206\u6790\u3002\u83b7\u53d6API\u5bc6\u94a5\u8bf7\u8bbf\u95ee',
+    apiConsole: '\u706b\u5c71\u5f15\u64ceARK\u63a7\u5236\u53f0',
+    apiKeyLabel: '\u8c46\u5305 API \u5bc6\u94a5',
+    test: '\u6d4b\u8bd5',
+    helpText:
+      '\u60a8\u7684API\u5bc6\u94a5\u4ec5\u5b58\u50a8\u5728\u672c\u5730\uff0c\u7edd\u4e0d\u4f1a\u5171\u4eab\u3002\u6ca1\u6709\u5bc6\u94a5\u5c06\u4f7f\u7528\u6f14\u793a\u6a21\u5f0f\u3002',
+    preferences: '\u2699\ufe0f \u504f\u597d\u8bbe\u7f6e',
+    language: '\u8bed\u8a00',
+    optionChinese: '\u4e2d\u6587 (Chinese)',
+    optionEnglish: '\u82f1\u6587 (English)',
+    enableNotifications: '\u542f\u7528\u901a\u77e5',
+    saveSettings: '\u4fdd\u5b58\u8bbe\u7f6e',
+    saving: '\u4fdd\u5b58\u4e2d...',
+    savedSuccess: '\u8bbe\u7f6e\u4fdd\u5b58\u6210\u529f\uff01',
+    invalidApiKeyFormat: 'API\u5bc6\u94a5\u683c\u5f0f\u65e0\u6548\uff0c\u8bf7\u68c0\u67e5\u60a8\u7684\u5bc6\u94a5\u3002',
+    pleaseEnterApiKeyFirst: '\u8bf7\u5148\u8f93\u5165API\u5bc6\u94a5',
+    testingApiKey: '\u6b63\u5728\u6d4b\u8bd5API\u5bc6\u94a5...',
+    invalidApiKey: '\u274c \u65e0\u6548\u7684API\u5bc6\u94a5',
+    apiKeyQuotaExceeded: '\u26a0\ufe0f API\u5bc6\u94a5\u6709\u6548\u4f46\u989d\u5ea6\u5df2\u7528\u5b8c',
+    apiKeyValid: '\u2705 API\u5bc6\u94a5\u6709\u6548',
+    unexpectedResponse: '\u26a0\ufe0f \u610f\u5916\u54cd\u5e94:',
+    networkError: '\u274c \u7f51\u7edc\u9519\u8bef\u6216\u65e0\u6548API\u5bc6\u94a5',
+    apiUsageInfo: '\ud83d\udccb API \u4f7f\u7528\u4fe1\u606f',
+    model: '\u6a21\u578b:',
+    features: '\u7279\u6027:',
+    featuresDesc: '\u4e2d\u6587\u6587\u672c\u8bc6\u522b\uff0c\u9519\u8bef\u68c0\u6d4b',
+    cost: '\u8d39\u7528:',
+    costDesc: '\u6839\u636e\u706b\u5c71\u5f15\u64ce\u5957\u9910\u6309\u91cf\u8ba1\u8d39',
+    security: '\u5b89\u5168:',
+    securityDesc: 'API\u5bc6\u94a5\u4ec5\u5b58\u5728\u672c\u5730\uff0c\u4e0d\u4f1a\u4e0a\u4f20\u5230\u670d\u52a1\u5668',
+  },
+};
+
+type TranslationKey = keyof typeof translations['en-US'];
+
 const Settings: React.FC<SettingsProps> = ({ user, onLogout }) => {
   const navigate = useNavigate();
   const [settings, setSettings] = useState<UserSettings>({
@@ -28,6 +107,8 @@ const Settings: React.FC<SettingsProps> = ({ user, onLogout }) => {
   const [showApiKey, setShowApiKey] = useState(false);
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState('');
+
+  const t = (key: TranslationKey): string => translations[settings.language][key];
 
   useEffect(() => {
     // Load user settings from localStorage
@@ -44,16 +125,16 @@ const Settings: React.FC<SettingsProps> = ({ user, onLogout }) => {
     try {
       // Validate API key format (basic validation)
       if (settings.apiKey && !isValidApiKey(settings.apiKey)) {
-        throw new Error('Invalid API key format. Please check your key.');
+        throw new Error(t('invalidApiKeyFormat'));
       }
 
       // Save to localStorage (in production, this would be saved to your backend)
       localStorage.setItem(`userSettings_${user.id}`, JSON.stringify(settings));
-      
-      setMessage('Settings saved successfully!');
+
+      setMessage(t('savedSuccess'));
       setTimeout(() => setMessage(''), 3000);
     } catch (error) {
-      setMessage(error instanceof Error ? error.message : 'Failed to save settings');
+      setMessage(error instanceof Error ? error.message : t('networkError'));
     } finally {
       setSaving(false);
     }
@@ -70,12 +151,12 @@ const Settings: React.FC<SettingsProps> = ({ user, onLogout }) => {
 
   const testApiKey = async () => {
     if (!settings.apiKey) {
-      setMessage('Please enter an API key first');
+      setMessage(t('pleaseEnterApiKeyFirst'));
       return;
     }
 
     setSaving(true);
-    setMessage('Testing API key...');
+    setMessage(t('testingApiKey'));
 
     try {
       // Simple test call to verify API key
@@ -93,16 +174,16 @@ const Settings: React.FC<SettingsProps> = ({ user, onLogout }) => {
       });
 
       if (response.status === 401) {
-        setMessage('❌ Invalid API key');
+        setMessage(t('invalidApiKey'));
       } else if (response.status === 429) {
-        setMessage('⚠️ API key valid but quota exceeded');
+        setMessage(t('apiKeyQuotaExceeded'));
       } else if (response.ok || response.status === 400) {
-        setMessage('✅ API key is valid');
+        setMessage(t('apiKeyValid'));
       } else {
-        setMessage(`⚠️ Unexpected response: ${response.status}`);
+        setMessage(`${t('unexpectedResponse')} ${response.status}`);
       }
     } catch (error) {
-      setMessage('❌ Network error or invalid API key');
+      setMessage(t('networkError'));
     } finally {
       setSaving(false);
     }
@@ -111,28 +192,28 @@ const Settings: React.FC<SettingsProps> = ({ user, onLogout }) => {
   return (
     <div className="settings-container">
       <header className="settings-header">
-        <h1>Account Settings</h1>
+        <h1>{t('accountSettings')}</h1>
         <div className="header-actions">
           <button onClick={() => navigate('/upload')} className="back-button">
-            ← Back to Upload
+            {t('backToUpload')}
           </button>
           <div className="user-info">
-            <span>Welcome, {user.username}</span>
-            <button onClick={onLogout} className="logout-button">Logout</button>
+            <span>{settings.language === 'zh-CN' ? `欢迎, ${user.username}` : `Welcome, ${user.username}`}</span>
+            <button onClick={onLogout} className="logout-button">{t('logout')}</button>
           </div>
         </div>
       </header>
 
       <main className="settings-main">
         <div className="settings-section">
-          <h2>🔑 API Configuration</h2>
+          <h2>{t('apiConfiguration')}</h2>
           <p className="section-description">
-            Configure your own Doubao API key for homework analysis. Get your API key from 
-            <a href="https://console.volcengine.com/ark" target="_blank" rel="noopener noreferrer"> Volcengine ARK Console</a>.
+            {t('apiDescription')}
+            <a href="https://console.volcengine.com/ark" target="_blank" rel="noopener noreferrer"> {t('apiConsole')}</a>.
           </p>
 
           <div className="form-group">
-            <label htmlFor="apiKey">Doubao API Key</label>
+            <label htmlFor="apiKey">{t('apiKeyLabel')}</label>
             <div className="api-key-input">
               <input
                 type={showApiKey ? 'text' : 'password'}
@@ -155,28 +236,28 @@ const Settings: React.FC<SettingsProps> = ({ user, onLogout }) => {
                 disabled={!settings.apiKey || saving}
                 className="test-button"
               >
-                Test
+                {t('test')}
               </button>
             </div>
             <small className="help-text">
-              Your API key is stored locally and never shared. Without a key, you'll use the demo mode.
+              {t('helpText')}
             </small>
           </div>
         </div>
 
         <div className="settings-section">
-          <h2>⚙️ Preferences</h2>
-          
+          <h2>{t('preferences')}</h2>
+
           <div className="form-group">
-            <label htmlFor="language">Language</label>
+            <label htmlFor="language">{t('language')}</label>
             <select
               id="language"
               value={settings.language}
               onChange={(e) => setSettings(prev => ({ ...prev, language: e.target.value as 'zh-CN' | 'en-US' }))}
               className="language-select"
             >
-              <option value="zh-CN">中文 (Chinese)</option>
-              <option value="en-US">English</option>
+              <option value="zh-CN">{t('optionChinese')}</option>
+              <option value="en-US">{t('optionEnglish')}</option>
             </select>
           </div>
 
@@ -187,7 +268,7 @@ const Settings: React.FC<SettingsProps> = ({ user, onLogout }) => {
                 checked={settings.notifications}
                 onChange={(e) => setSettings(prev => ({ ...prev, notifications: e.target.checked }))}
               />
-              <span>Enable notifications</span>
+              <span>{t('enableNotifications')}</span>
             </label>
           </div>
         </div>
@@ -198,7 +279,7 @@ const Settings: React.FC<SettingsProps> = ({ user, onLogout }) => {
             disabled={saving}
             className="save-button"
           >
-            {saving ? 'Saving...' : 'Save Settings'}
+            {saving ? t('saving') : t('saveSettings')}
           </button>
         </div>
 
@@ -209,12 +290,12 @@ const Settings: React.FC<SettingsProps> = ({ user, onLogout }) => {
         )}
 
         <div className="info-section">
-          <h3>📋 API Usage Information</h3>
+          <h3>{t('apiUsageInfo')}</h3>
           <ul>
-            <li><strong>Model:</strong> doubao-seed-1-6-flash-250715</li>
-            <li><strong>Features:</strong> Chinese text recognition, error detection</li>
-            <li><strong>Cost:</strong> Pay-per-use based on your Volcengine plan</li>
-            <li><strong>Security:</strong> API key stored locally, not on our servers</li>
+            <li><strong>{t('model')}</strong> doubao-seed-1-6-flash-250715</li>
+            <li><strong>{t('features')}</strong> {t('featuresDesc')}</li>
+            <li><strong>{t('cost')}</strong> {t('costDesc')}</li>
+            <li><strong>{t('security')}</strong> {t('securityDesc')}</li>
           </ul>
         </div>
       </main>

--- a/src/components/Upload.tsx
+++ b/src/components/Upload.tsx
@@ -84,10 +84,24 @@ const Upload: React.FC<UploadProps> = ({ user, onLogout, onAnalysisComplete, onN
     setAnalyzing(true);
 
     try {
+      // Determine user preferred language from saved settings
+      let userLanguage: 'zh-CN' | 'en-US' = 'en-US';
+      const savedSettings = localStorage.getItem(`userSettings_${user.id}`);
+      if (savedSettings) {
+        try {
+          const parsed = JSON.parse(savedSettings);
+          if (parsed.language === 'zh-CN' || parsed.language === 'en-US') {
+            userLanguage = parsed.language;
+          }
+        } catch {
+          // ignore parse errors and use default
+        }
+      }
+
       // Call Doubao API service
       const analysisResult = await DoubaoAPIService.analyzeHomework({
         imageData: previewUrl,
-        userLanguage: 'zh-CN',
+        userLanguage,
         userId: user.id
       });
       


### PR DESCRIPTION
## Summary
- add translation dictionary and dynamic language switching to Settings page
- use saved language preference when calling analysis API

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1e1053ee4832eb49959f875190506